### PR TITLE
fix: remove unexpected leading space for empty prefix

### DIFF
--- a/lib/loglevel-plugin-prefix.js
+++ b/lib/loglevel-plugin-prefix.js
@@ -97,7 +97,9 @@
 
           if (args.length && typeof args[0] === 'string') {
             // concat prefix with first argument to support string substitutions
-            args[0] = content + ' ' + args[0];
+            if (content.length) {
+              args[0] = content + ' ' + args[0];
+            }
           } else {
             args.unshift(content);
           }


### PR DESCRIPTION
Related issue: https://github.com/kutuluk/loglevel-plugin-prefix/issues/10